### PR TITLE
Add 'newblock' command to bet, tie into test_loop() func

### DIFF
--- a/privatebet/bet.c
+++ b/privatebet/bet.c
@@ -489,11 +489,19 @@ static void bet_start(int argc, char **argv){
 			bet_handle_game(argc, argv);
 			break;
 		cases("h")
-		cases("-h") 
+		cases("-h")
 		cases("help")
 		cases("--help")
 			if (argc == 3) {
 				bet_help_command(argv[2]);
+			} else {
+				bet_command_info();
+			}
+			break;
+		cases("newblock")
+			if (argc == 3) {
+				dlg_info("Received new block notification for block with hash: %s...",argv[2]);
+                                test_loop(argv[2]);
 			} else {
 				bet_command_info();
 			}
@@ -509,7 +517,7 @@ static void bet_start(int argc, char **argv){
 					sleep(5);
 				}
 			} while (dealer_ip == NULL);
-			
+
 			if (dealer_ip) {
 				dlg_info("The dealer is :: %s", dealer_ip);
 				bet_player_thrd(dealer_ip);
@@ -600,6 +608,13 @@ static void bet_start(int argc, char **argv)
 		} else {
 			bet_command_info();
 		}
+	} else if (strcmp(argv[1], "newblock") == 0) {
+		if (argc == 3) {
+			dlg_info("Received new block notification for block with hash: %s...",argv[2]);
+                        test_loop(argv[2]);
+		} else {
+			bet_command_info();
+		}
 	} else if (strcmp(argv[1], "player") == 0) {
 		playing_nodes_init();
 		bet_parse_verus_player();
@@ -668,7 +683,7 @@ static void bet_start(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-	test_loop();
+	//test_loop();
 	bet_start(argc, argv);
 	return OK;
 }

--- a/privatebet/vdxf.c
+++ b/privatebet/vdxf.c
@@ -408,33 +408,39 @@ end:
 	return argjson;
 }
 
-void test_loop()
+void test_loop(char *blockhash)
 {
+        dlg_info("%s called!",__FUNCTION__);
 	char verus_addr[1][100] = { "cashiers.poker.chips10sec@" };
-	int32_t blockcount = 149267, temp;
-
-	while (1) {
-		sleep(5);
-		temp = blockcount;
-		cJSON *argjson = cJSON_CreateObject();
-		argjson = getaddressutxos(verus_addr, 1);
-
-		for (int32_t i = 0; i < cJSON_GetArraySize(argjson); i++) {
-			if (jint(cJSON_GetArrayItem(argjson, i), "height") > blockcount) {
-				if (temp < jint(cJSON_GetArrayItem(argjson, i), "height")) {
-					temp = jint(cJSON_GetArrayItem(argjson, i), "height");
-				}
-				dlg_info("%s::%d::tx_to_process::%s\n", __FUNCTION__, __LINE__,
-					 cJSON_Print(cJSON_GetArrayItem(argjson, i)));
-				cJSON *temp =
-					chips_extract_tx_data_in_JSON(jstr(cJSON_GetArrayItem(argjson, i), "txid"));
-				dlg_info("%s::%d::tx_data::%s\n", __FUNCTION__, __LINE__, cJSON_Print(temp));
-				cJSON *primaryaddress = cJSON_CreateArray();
-				cJSON_AddItemToArray(primaryaddress, cJSON_CreateString(jstr(temp, "primaryaddress")));
-				cJSON *temp2 = append_primaryaddresses(jstr(temp, "table_id"), primaryaddress);
-				dlg_info("%s::%d::%s\n", __FUNCTION__, __LINE__, cJSON_Print(temp2));
-			}
+	int32_t blockcount = 0;
+	cJSON *blockjson = cJSON_CreateObject();
+	blockjson = chips_get_block_from_block_hash(blockhash);
+        dlg_info("%s::%d::block_data::%s",__FUNCTION__,__LINE__,cJSON_Print(blockjson));
+   	for (int32_t i = 0; i < cJSON_GetArraySize(blockjson); i++) {
+		blockcount = jint(cJSON_GetArrayItem(blockjson,i), "height");
+		if (blockcount > 0) {
+			dlg_info("%s: received blockhash in test_loop, found at height = %d",__FUNCTION__,blockcount);
+			break;
 		}
-		blockcount = temp;
+	}
+
+	cJSON *argjson = cJSON_CreateObject();
+	argjson = getaddressutxos(verus_addr, 1);
+
+	for (int32_t i = 0; i < cJSON_GetArraySize(argjson); i++) {
+		if (jint(cJSON_GetArrayItem(argjson, i), "height") != 0) {
+		//if (jint(cJSON_GetArrayItem(argjson, i), "height") == blockcount) {
+			//TODO: condition above seems error-prone with 10s blocks...
+			// also, it won't update on init, since prior update may well be in past
+			dlg_info("%s::%d::tx_to_process::%s\n", __FUNCTION__, __LINE__,
+				 cJSON_Print(cJSON_GetArrayItem(argjson, i)));
+			cJSON *temp =
+				chips_extract_tx_data_in_JSON(jstr(cJSON_GetArrayItem(argjson, i), "txid"));
+			dlg_info("%s::%d::tx_data::%s\n", __FUNCTION__, __LINE__, cJSON_Print(temp));
+			cJSON *primaryaddress = cJSON_CreateArray();
+			cJSON_AddItemToArray(primaryaddress, cJSON_CreateString(jstr(temp, "primaryaddress")));
+			cJSON *temp2 = append_primaryaddresses(jstr(temp, "table_id"), primaryaddress);
+			dlg_info("%s::%d::%s\n", __FUNCTION__, __LINE__, cJSON_Print(temp2));
+		}
 	}
 }

--- a/privatebet/vdxf.h
+++ b/privatebet/vdxf.h
@@ -70,4 +70,4 @@ struct table *find_table();
 bool is_id_exists(char *id, int16_t full_id);
 void verus_sendcurrency_data(cJSON *data);
 cJSON *getaddressutxos(char verus_addresses[][100], int n);
-void test_loop();
+void test_loop(char *block_hash);


### PR DESCRIPTION
This PR is not quite complete, there are a few cases we need to handle:

1.) May need to check for integrity of `blocknotify`-supplied data (getbestblockhash), ensure they match
2.) Handle first update on `init`, then only update when `height` value of `getaddressutxos` response matches height from `getblock` fetched by hash (i.e. when we have fresh data)

Might be more I haven't thought of... but, after merging this into `bet`, add the following to config file:

`blocknotify=$HOME/bet/privatebet/bet newblock %s`

(Located at: `$HOME/.verustest/pbaas/da67c931cb4f33ab234fa4fa4a5b5365d77052ba/da67c931cb4f33ab234fa4fa4a5b5365d77052ba.conf`)

Once you relaunch `chips10sec`, you'll see output from bet displaying in terminal where you launched `verusd`